### PR TITLE
fix of dec-22: downgrade awscli due to dep conflict

### DIFF
--- a/ivy-zap2docker/Dockerfile
+++ b/ivy-zap2docker/Dockerfile
@@ -1,4 +1,10 @@
 FROM owasp/zap2docker-weekly
 
 ENV PATH="${PATH}:/home/zap/.local/bin"
-RUN pip install -v --upgrade zapcli
+RUN pip install -v\
+ awscli==1.25.83\
+ --upgrade zapcli
+
+USER root
+RUN usermod -u 1000 zap && groupmod -g 1000 zap
+RUN chown -R zap:zap /zap


### PR DESCRIPTION
- awscli -> urllib3 vs. zapcli -> urllib version
- better long-term solution: do not use zapcli, this thing is unmaintained since 2018